### PR TITLE
Typo fixes

### DIFF
--- a/data/blueprints.xml.append
+++ b/data/blueprints.xml.append
@@ -5910,7 +5910,7 @@ Cooldown will not go below 1x, Instead power scales number of shots.</desc>
 	<title>Shockfish</title>
 	<short>Shockfish</short>
 	<tip>tip_ion</tip>
-	<desc>Similiar to an ion weapon, however it shocks crew and causes them to run to a random room.</desc>
+	<desc>Similar to an ion weapon, however it shocks crew and causes them to run to a random room.</desc>
 	<tooltip>Fires 1 projectiles, 1 ion damage, sends crew away from the room.</tooltip>
 	<damage>0</damage>
 	<ion>1</ion>
@@ -6092,7 +6092,7 @@ Cooldown will not go below 1x, Instead power scales number of shots.</desc>
 	<title>Breachfish</title>
 	<short>Breachfish</short>
 	<desc>A fish specialized in breaching enemy ships, is capable of penetrating through super shields.</desc>
-	<tooltip>Fires 1 missile, does 3 damage, garenteed breach, penetrates super shields</tooltip>
+	<tooltip>Fires 1 missile, does 3 damage, guaranteed breach, penetrates super shields</tooltip>
 	<damage>3</damage>
 	<missiles>1</missiles>
 	<shots>1</shots>
@@ -7058,8 +7058,8 @@ Default Price: 80~ - Selling Price:40~
 	<type>BEAM</type>
 	<flavorType>Fish</flavorType>
 	<tip>tip_fish_food</tip>
-	<title>Spotted Mackeral</title>
-	<short>Spotted Mackeral</short>
+	<title>Spotted Mackerel</title>
+	<short>Spotted Mackerel</short>
 	<desc>A basic space fish, when consumed gives a +5% movement speed bonus to all crew</desc>
 	<tooltip>Fish</tooltip>
 	<damage>0</damage>
@@ -7899,7 +7899,7 @@ Default Price: 80~ - Selling Price:40~
 	<tip>tip_fish_food</tip>
 	<title>Shorefish</title>
 	<short>Shorefish</short>
-	<desc>A legendary space fish, when consumed makes your crew incapable of repairing, however all systems now autorepair at speeds equivilent to two crew members repairing.</desc>
+	<desc>A legendary space fish, when consumed makes your crew incapable of repairing, however all systems now autorepair at speeds equivalent to two crew members repairing.</desc>
 	<tooltip>Fish</tooltip>
 	<damage>0</damage>
 	<sp>0</sp>
@@ -8399,7 +8399,7 @@ Default Price: 80~ - Selling Price:40~
 	<tip>tip_fish_food</tip>
 	<title>Ancient Fish</title>
 	<short>Ancient Fish</short>
-	<desc>A unique space fish, can be consumed to upgrade an obelisk weapon to the royal varient.</desc>
+	<desc>A unique space fish, can be consumed to upgrade an obelisk weapon to the royal variant.</desc>
 	<tooltip>Fish</tooltip>
 	<damage>0</damage>
 	<sp>0</sp>

--- a/data/events_special_fish_maw.xml
+++ b/data/events_special_fish_maw.xml
@@ -14,7 +14,7 @@ There appears to note scratched into the generator.
 	<choice>
 		<text>Sabotage the generator.</text>
 		<event>
-            <text>You quickly destroy the oxygen generator, it's unlikely you'll be seeing this station again, atleast in this universe.</text>
+            <text>You quickly destroy the oxygen generator, it's unlikely you'll be seeing this station again, at least in this universe.</text>
             <variable name="fishing_store_visited" op="set" val="0"/>
             <status type="limit" target="enemy" system="oxygen" amount="0" />
             <status type="limit" target="enemy" system="weapons" amount="0" />
@@ -33,7 +33,7 @@ There appears to note scratched into the generator.
 <event name="FISHING_STORE_KILLED">
     <text>The station has been emptied of crew.
 
-You recieve an empty message
+You receive an empty message
 There's a set of coordinates attached...</text>
     <variable name="fishing_store_killed" op="set" val="1"/>
     <quest event="FISHING_MAW_QUEST"/>

--- a/data/events_special_fishing.xml
+++ b/data/events_special_fishing.xml
@@ -156,7 +156,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="fish_bait_bounty_11" lvl="4" max_lvl="4">
-        <text>Bounty 1: Spotted Mackeral</text>
+        <text>Bounty 1: Spotted Mackerel</text>
         <event>
             <loadEvent>FISH_BOUNTY_11_4</loadEvent>
         </event>
@@ -218,7 +218,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="fish_bait_bounty_12" lvl="4" max_lvl="4">
-        <text>Bounty 2: Spotted Mackeral</text>
+        <text>Bounty 2: Spotted Mackerel</text>
         <event>
             <loadEvent>FISH_BOUNTY_12_4</loadEvent>
         </event>
@@ -280,7 +280,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="fish_bait_bounty_13" lvl="4" max_lvl="4">
-        <text>Bounty 3: Spotted Mackeral</text>
+        <text>Bounty 3: Spotted Mackerel</text>
         <event>
             <loadEvent>FISH_BOUNTY_13_4</loadEvent>
         </event>
@@ -342,7 +342,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="fish_bait_bounty_14" lvl="4" max_lvl="4">
-        <text>Bounty 4: Spotted Mackeral</text>
+        <text>Bounty 4: Spotted Mackerel</text>
         <event>
             <loadEvent>FISH_BOUNTY_14_4</loadEvent>
         </event>
@@ -404,7 +404,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="fish_bait_bounty_15" lvl="4" max_lvl="4">
-        <text>Bounty 5: Spotted Mackeral</text>
+        <text>Bounty 5: Spotted Mackerel</text>
         <event>
             <loadEvent>FISH_BOUNTY_15_4</loadEvent>
         </event>
@@ -1187,7 +1187,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event>
             <remove name="FISH_FOOD_4"/>
             <augment name="FISH_BAIT_11"/>
@@ -1196,7 +1196,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4" lvl="0" max_lvl="0" hidden="true">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event load="OPTION_INVALID"/>
     </choice>
     <choice>
@@ -1499,7 +1499,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event>
             <remove name="FISH_FOOD_4"/>
             <augment name="FISH_BAIT_12"/>
@@ -1508,7 +1508,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4" lvl="0" max_lvl="0" hidden="true">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event load="OPTION_INVALID"/>
     </choice>
     <choice>
@@ -1811,7 +1811,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event>
             <remove name="FISH_FOOD_4"/>
             <augment name="FISH_BAIT_13"/>
@@ -1820,7 +1820,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4" lvl="0" max_lvl="0" hidden="true">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event load="OPTION_INVALID"/>
     </choice>
     <choice>
@@ -2123,7 +2123,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event>
             <remove name="FISH_FOOD_4"/>
             <augment name="FISH_BAIT_14"/>
@@ -2132,7 +2132,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4" lvl="0" max_lvl="0" hidden="true">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event load="OPTION_INVALID"/>
     </choice>
     <choice>
@@ -2435,7 +2435,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event>
             <remove name="FISH_FOOD_4"/>
             <augment name="FISH_BAIT_15"/>
@@ -2444,7 +2444,7 @@ It appears they have a bounty board setup for fish, The rewards appear quite val
         </event>
     </choice>
     <choice req="FISH_FOOD_4" lvl="0" max_lvl="0" hidden="true">
-        <text>Spotted Mackeral</text>
+        <text>Spotted Mackerel</text>
         <event load="OPTION_INVALID"/>
     </choice>
     <choice>

--- a/data/events_special_lightspeed.xml.append
+++ b/data/events_special_lightspeed.xml.append
@@ -109,7 +109,7 @@
   <autoReward level="LOW">stuff</autoReward>
 </event>
 <event name="FISH_SCRAP_2">
-  <text>You've pulled up a heap of junk, atleast there are some useful components in the mix.</text>
+  <text>You've pulled up a heap of junk, at least there are some useful components in the mix.</text>
   <autoReward level="MED">stuff</autoReward>
 </event>
 <event name="FISH_SCRAP_3">
@@ -139,7 +139,7 @@
 </event>
 <event name="FISH_ENGI_GIVE">
   <variable name="fish_caught_unique" op="add" val="1"/>
-  <text>You reeled in a unique engi fish!</text>
+  <text>You reeled in a unique Engi fish!</text>
   
   <weapon name="FISH_FOOD_43"/>
   <choice>
@@ -149,7 +149,7 @@
 </event>
 <event name="FISH_ZOL_GIVE">
   <variable name="fish_caught_unique" op="add" val="1"/>
-  <text>You reeled in a unique zoltan fish!</text>
+  <text>You reeled in a unique Zoltan fish!</text>
   
   <weapon name="FISH_FOOD_44"/>
   <choice>

--- a/data/events_special_multiverse.xml.append
+++ b/data/events_special_multiverse.xml.append
@@ -12,7 +12,7 @@
 	<mod-append:choice hidden="true" req="BLUELIST_FISH" blue="false">
         <text>Present a fish.</text>
         <event>
-            <text>"This... this is a fish? I'm not sure why you have brought me this, however this IS tribute, if only becuase I'm not sure how you got your hands on it. I shall BLESS you with the BLESSING OF FISH. But have PATIENCE. It is not for now, but for LATER!"</text>
+            <text>"This... this is a fish? I'm not sure why you have brought me this, however this IS tribute, if only because I'm not sure how you got your hands on it. I shall BLESS you with the BLESSING OF FISH. But have PATIENCE. It is not for now, but for LATER!"</text>
             <achievement silent="false">ACH_BOON_FISH</achievement>
             <metaVariable name="prof_r_boon_fish" op="set" val="1" />
             <choice hidden="true">

--- a/data/events_special_storage.xml.append
+++ b/data/events_special_storage.xml.append
@@ -295,7 +295,7 @@
     </event>
   </choice>
   <choice req="FISH_FOOD_4">
-    <text>Cook the Spotted Mackeral. (+5% move speed)</text>
+    <text>Cook the Spotted Mackerel. (+5% move speed)</text>
     <event>
       <remove name="FISH_FOOD_4"/>
       <hiddenAug>FISH_AUG_4</hiddenAug>
@@ -712,7 +712,7 @@
     </event>
   </choice-->
   <choice req="FISH_FOOD_4D">
-    <text>Cook the Ancient Fish. (Upgrades 1 obelisk weapon to the royal varient)</text>
+    <text>Cook the Ancient Fish. (Upgrades 1 obelisk weapon to the royal variant)</text>
     <event load="STORAGE_CHECK_ANC_UPGRADE" />
   </choice>
   <choice req="FISH_FOOD_4E">
@@ -1973,7 +1973,7 @@
   </choice>
 
   <choice blue="false" req="fish_inaug_bait_check" >
-    <text>Improved bait. (Reduces chance of recieving junk)</text>
+    <text>Improved bait. (Reduces chance of receiving junk)</text>
     <event>
       <text>You install the improved bait.</text>
       <item_modify>
@@ -1989,7 +1989,7 @@
     </event>
   </choice>
   <!--choice blue="false" req="fish_inaug_bait_alt_check" >
-    <text>Improved bait. (Reduces chance of recieving junk)</text>
+    <text>Improved bait. (Reduces chance of receiving junk)</text>
     <event>
       <text>You install the improved bait.</text>
       <item_modify>
@@ -2117,13 +2117,13 @@
 
 <event name="STORAGE_CHECK_FISHING_INFO">
   <text>Fishing rewards are calculated as such;
-When you catch a fish it first calculates the chance of getting junk, intially this is a 3/4 chance, which is reduced to 2/3 by the internal augment, and 0/1 by the boon and fishing vessel augment.
+When you catch a fish it first calculates the chance of getting junk, initially this is a 3/4 chance, which is reduced to 2/3 by the internal augment, and 0/1 by the boon and fishing vessel augment.
 If it decided you caught junk theres a 50% chance of a basic fish and a 50% chance for a junk item (The useless items worth 5 scrap).
-(This does not apply to the glowing blue fish which is a garenteed legendary fish.)
+(This does not apply to the glowing blue fish which is a guaranteed legendary fish.)
 
 Otherwise the fishing loot is determined by the loot table corresponding to the difficulty of fish you caught. There are different loot tables depending on your sector.
 
-Fish difficulty is determined when you start fishing, normally its a number from 1 to the strength of your harpoon, a MK 1 has a strength of 5, a MK 2 a strength of 10, and a MK 3 a stregth of 16.
+Fish difficulty is determined when you start fishing, normally its a number from 1 to the strength of your harpoon, a MK 1 has a strength of 5, a MK 2 a strength of 10, and a MK 3 a strength of 16.
 The MK2 and MK3 will raise the lower bound of the difficulty if you have the internal augment to make basic fish rarer.
 
 Basic, Uncommon and Rare fishing bonuses all stack multiplicatively, they also only apply to your own crew.
@@ -2146,7 +2146,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     <event load="STORAGE_CHECK_FISHING_LOAD"/>
   </choice>
   <choice req="fish_bait_equip_11" blue="false">
-    <text>Currently equiped bait: No Scrap</text>
+    <text>Currently equipped bait: No Scrap</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2154,7 +2154,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_12" blue="false">
-    <text>Currently equiped bait: Less Generic Fish</text>
+    <text>Currently equipped bait: Less Generic Fish</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2162,7 +2162,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_13" blue="false">
-    <text>Currently equiped bait: No Gun or Unique Fish</text>
+    <text>Currently equipped bait: No Gun or Unique Fish</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2170,7 +2170,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_14" blue="false">
-    <text>Currently equiped bait: No Crew</text>
+    <text>Currently equipped bait: No Crew</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2178,7 +2178,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_15" blue="false">
-    <text>Currently equiped bait: No Equipment</text>
+    <text>Currently equipped bait: No Equipment</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2187,7 +2187,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
   </choice>
   
   <choice req="fish_bait_equip_21" blue="false">
-    <text>Currently equiped bait: No Scrap/Less Generic Fish</text>
+    <text>Currently equipped bait: No Scrap/Less Generic Fish</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2195,7 +2195,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_22" blue="false">
-    <text>Currently equiped bait: Less Generic Fish/No Gun or Unique Fish</text>
+    <text>Currently equipped bait: Less Generic Fish/No Gun or Unique Fish</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2203,7 +2203,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_23" blue="false">
-    <text>Currently equiped bait: No Gun or Unique Fish/No Crew</text>
+    <text>Currently equipped bait: No Gun or Unique Fish/No Crew</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2211,7 +2211,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_24" blue="false">
-    <text>Currently equiped bait: No Crew/No Equipment</text>
+    <text>Currently equipped bait: No Crew/No Equipment</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2219,7 +2219,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_25" blue="false">
-    <text>Currently equiped bait: No Equipment/No Scrap</text>
+    <text>Currently equipped bait: No Equipment/No Scrap</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2228,7 +2228,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
   </choice>
   
   <choice req="fish_bait_equip_31" blue="false">
-    <text>Currently equiped bait: No Scrap/Less Generic Fish/No Gun or Unique Fish</text>
+    <text>Currently equipped bait: No Scrap/Less Generic Fish/No Gun or Unique Fish</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2236,7 +2236,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_32" blue="false">
-    <text>Currently equiped bait: Less Generic Fish/No Gun or Unique Fish/No Crew</text>
+    <text>Currently equipped bait: Less Generic Fish/No Gun or Unique Fish/No Crew</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2244,7 +2244,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_33" blue="false">
-    <text>Currently equiped bait: No Gun or Unique Fish/No Crew/No Equipment</text>
+    <text>Currently equipped bait: No Gun or Unique Fish/No Crew/No Equipment</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2252,7 +2252,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_34" blue="false">
-    <text>Currently equiped bait: No Crew/No Equipment/No Scrap</text>
+    <text>Currently equipped bait: No Crew/No Equipment/No Scrap</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2260,7 +2260,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_35" blue="false">
-    <text>Currently equiped bait: No Equipment/No Scrap/Less Generic Fish</text>
+    <text>Currently equipped bait: No Equipment/No Scrap/Less Generic Fish</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2268,7 +2268,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     </event>
   </choice>
   <choice req="fish_bait_equip_DOUBLE" blue="false">
-    <text>Currently equiped bait: Double Hook</text>
+    <text>Currently equipped bait: Double Hook</text>
     <event>
       <text>1</text>
       <loadEvent>STORAGE_CHECK_FISHING_BAIT</loadEvent>
@@ -2950,7 +2950,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     <text>Bounty 0: Queenfish</text>
     <event load="OPTION_INVALID"/>
   </choice>
-  <choice req="ffish_bait_bounty_DOUBLE" lvl="2" max_lvl="2" hidden="true">
+  <choice req="fish_bait_bounty_DOUBLE" lvl="2" max_lvl="2" hidden="true">
     <text>Bounty 0: Mahi Mahi</text>
     <event load="OPTION_INVALID"/>
   </choice>
@@ -2989,7 +2989,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
     <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_11" hidden="true" lvl="4" max_lvl="4">
-    <text>Bounty 1: Spotted Mackeral</text>
+    <text>Bounty 1: Spotted Mackerel</text>
     <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_11" hidden="true" lvl="5" max_lvl="5">
@@ -3031,7 +3031,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_12" hidden="true" lvl="4" max_lvl="4">
-      <text>Bounty 2: Spotted Mackeral</text>
+      <text>Bounty 2: Spotted Mackerel</text>
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_12" hidden="true" lvl="5" max_lvl="5">
@@ -3073,7 +3073,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_13" hidden="true" lvl="4" max_lvl="4">
-      <text>Bounty 3: Spotted Mackeral</text>
+      <text>Bounty 3: Spotted Mackerel</text>
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_13" hidden="true" lvl="5" max_lvl="5">
@@ -3115,7 +3115,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_14" hidden="true" lvl="4" max_lvl="4">
-      <text>Bounty 4: Spotted Mackeral</text>
+      <text>Bounty 4: Spotted Mackerel</text>
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_14" hidden="true" lvl="5" max_lvl="5">
@@ -3157,7 +3157,7 @@ Other bonus will usually stack multiplicatively however they may apply to enemy 
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_15" hidden="true" lvl="4" max_lvl="4">
-      <text>Bounty 5: Spotted Mackeral</text>
+      <text>Bounty 5: Spotted Mackerel</text>
       <event load="OPTION_INVALID"/>
   </choice>
   <choice req="fish_bait_bounty_15" hidden="true" lvl="5" max_lvl="5">

--- a/data/hyperspace.xml.append
+++ b/data/hyperspace.xml.append
@@ -1333,8 +1333,8 @@
 				<multiDifficulty>false</multiDifficulty>
             </achievement>
             <achievement name="FISH_CAUGHT_4">
-                <name>Spotted Mackeral</name>
-                <description>Catch a Spotted Mackeral.</description>
+                <name>Spotted Mackerel</name>
+                <description>Catch a Spotted Mackerel.</description>
                 <header>Fish Caught!</header>
                 <icon>fish4</icon>
                 <variable name="fish_obtained_4" amount="1" />


### PR DESCRIPTION
Thanks for the cool mod! Just a few typo fixes (mostly in user-facing strings, along with one instance of "ffish_bait_bounty_DOUBLE".)